### PR TITLE
Replace site.find() with kirby.page()

### DIFF
--- a/site/blueprints/pages/note.yml
+++ b/site/blueprints/pages/note.yml
@@ -34,7 +34,7 @@ columns:
           tags: true
           gallery:
             type: pages
-            query: site.find("photography").children
+            query: kirby.page("photography").children
             multiple: false
             info: "{{ page.images.count }} image(s)"
             empty: "No gallery selected"

--- a/site/blueprints/pages/sandbox.yml
+++ b/site/blueprints/pages/sandbox.yml
@@ -16,4 +16,4 @@ fields:
         label: Image
         type: files
         max: 1
-        parent: site.find('photography').children.first
+        parent: kirby.page('photography').children.first

--- a/site/blueprints/sections/albums.yml
+++ b/site/blueprints/sections/albums.yml
@@ -1,6 +1,6 @@
 type: pages
 headline: Photography
-parent: site.find("photography")
+parent: kirby.page("photography")
 size: tiny
 info: "{{ page.images.count }} image(s)"
 layout: cards

--- a/site/blueprints/sections/notes.yml
+++ b/site/blueprints/sections/notes.yml
@@ -1,6 +1,6 @@
 type: pages
 headline: Notes
-parent: site.find("notes")
+parent: kirby.page("notes")
 info: "{{ page.date.toDate('d.m.Y') }}"
 template: note
 empty: No notes yet


### PR DESCRIPTION
This PR replaces the current way to find a page (`site.find()`) with `kirby.page()` to prevent errors in the Panel in case the parent's status is changed to draft.

While this might not always make sense, it probably does in the Starterkit context where people play around and where they otherwise don't have a chance to get back to the original state because the resulting error prevents the user to change the status back to published.