### PR TITLE
New composer start script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "php": ">=7.1.0",
         "getkirby/cms": "^3.0"
     },
+    "scripts": {
+        "start": "@php -S localhost:8000 kirby/router.php"
+    },  
     "config": {
         "optimize-autoloader": true
     }


### PR DESCRIPTION
You can now start the starterkit with `composer start`