### PR TITLE
Remove *.sublime-project from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ Icon
 
 # Editors
 # ---------------
-*.sublime-project
 *.sublime-workspace
 /.vscode
 /.idea


### PR DESCRIPTION
.sublime-project files should generally be checked into version control, see:
https://www.sublimetext.com/docs/3/projects.html