### PR TITLE
Remove `title` from `site.yml`

### DIFF
--- a/site/blueprints/site.yml
+++ b/site/blueprints/site.yml
@@ -1,6 +1,4 @@
-# The site blueprint must have a title, the title may be different from the file name
 # The `site.yml` blueprint defines the look of the start page (Dashboard) of the Panel.
-title: Site
 
 # The site blueprint usually provides easy access to all main pages of the site.
 # In this example blueprint, we also show subpages of the `photography` and `notes` pages.


### PR DESCRIPTION
To actually use `view.site` translation strings in the Panel.