### PR TITLE
Update because text field is blocks type

### DIFF
--- a/site/templates/album.php
+++ b/site/templates/album.php
@@ -25,7 +25,7 @@
 
     <div class="column" style="--columns: 4">
       <div class="text">
-        <?= $page->text() ?>
+        <?= $page->text()->toBlocks() ?>
       </div>
     </div>
 


### PR DESCRIPTION
Editing this page in the panel renders block code instead of the text.
Adding this fixes it, so that new users won't be confused when they see it all gobbledygonked.