### PR TITLE
composer.json: Allow Kirby Composer installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     ]
   },
   "config": {
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+    "allow-plugins": {
+      "getkirby/composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "cms",
     "starterkit"
   ],
-  "homepage": "https://getkirby.com",
   "authors": [
     {
       "name": "Bastian Allgeier",
@@ -15,6 +14,7 @@
       "homepage": "https://getkirby.com"
     }
   ],
+  "homepage": "https://getkirby.com",
   "support": {
     "email": "support@getkirby.com",
     "issues": "https://github.com/getkirby/starterkit/issues",
@@ -25,16 +25,16 @@
     "php": ">=7.4.0 <8.2.0",
     "getkirby/cms": "^3.6"
   },
+  "config": {
+    "allow-plugins": {
+      "getkirby/composer-installer": true
+    },
+    "optimize-autoloader": true
+  },
   "scripts": {
     "start": [
       "Composer\\Config::disableProcessTimeout",
       "@php -S localhost:8000 kirby/router.php"
     ]
-  },
-  "config": {
-    "optimize-autoloader": true,
-    "allow-plugins": {
-      "getkirby/composer-installer": true
-    }
   }
 }


### PR DESCRIPTION
This avoids this warning on `composer create-project`:

```
getkirby/composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "getkirby/composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
```

We will need the same changes in Demokit and Plainkit.