### PR TITLE
Use Symfony YAML handler

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -9,5 +9,5 @@
  */
 return [
     'debug' => true,
-    'yaml.handler' => 'symfony',
+    'yaml.handler' => 'symfony', // already makes use of the more modern Symfony YAML parser: https://getkirby.com/docs/reference/system/options/yaml (will become the default in a future Kirby version)
 ];

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -9,4 +9,5 @@
  */
 return [
     'debug' => true,
+    'yaml.handler' => 'symfony',
 ];


### PR DESCRIPTION
🚨 Only merge after 4.5.0 release

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes
- Switches to Symphony YAML handler


### Reasoning
Before we switch the default in the Core, it would be good to run our kits first with this handler. Gives us more chances to catch any issues/differences that the new handler has, which would then allow us to make the default switch easier for developers.
