### PR TITLE
fix: add PHP 8.4 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "source": "https://github.com/getkirby/starterkit"
   },
   "require": {
-    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
     "getkirby/cms": "^4.0"
   },
   "config": {


### PR DESCRIPTION
## Description
Since Kirby 4.6 is compatible with PHP 8.4, this should be reflected in the `composer.json`, too – right?