### PR TITLE
chore: Add workflow to sync Kirby on release

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,60 @@
+name: Sync Kirby
+on:
+  # Triggered by the getkirby/kirby release workflow
+  repository_dispatch:
+    types: [kirby-release]
+
+  # Allow manual runs for a specific version
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Kirby version/tag to install (e.g. 5.5.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: "Sync & tag"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Resolve version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version || github.event.client_payload.version }}"
+          if [ -z "$VERSION" ]; then
+            echo "No version provided" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download & replace kirby folder
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          curl -fsSL "https://github.com/getkirby/kirby/archive/refs/tags/${VERSION}.zip" -o kirby.zip
+          rm -rf kirby
+          unzip -q kirby.zip
+          mv "kirby-${VERSION}" kirby
+          rm kirby.zip
+
+      - name: Commit & tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes — kirby already at ${VERSION}"
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "Upgrade to ${VERSION}"
+          git tag "${VERSION}"
+          git push --follow-tags


### PR DESCRIPTION
## Auto-update the Kirby folder on release

This adds a workflow that updates the `kirby` folder in this repo whenever a new Kirby version is released, so we no longer have to do it by hand.

### How it works

The workflow gets a signal from `getkirby/kirby` when a release is published (see getkirby/kirby#9999). It then:

1. Reads the version number from that signal (for example `5.5.0`).
2. Downloads the matching `kirby` folder from the release.
3. Replaces the old `kirby` folder with the new one.
4. Commits the change and pushes a tag with the same version.

You can also run it by hand from the Actions tab ("Run workflow") and pass a version, for example to re-sync an older release.

If nothing changed (the folder is already on that version), the workflow stops without committing.

### Notes

- It uses the repo's own `GITHUB_TOKEN`, so no extra secret is needed here.
- If `main` is protected against direct pushes, GitHub Actions needs permission to push the commit and tag.
- This is the first kit to get the workflow. Once it works here, the same file goes into `plainkit` and `demokit`.